### PR TITLE
Ensure deploying user has added their ssh-key

### DIFF
--- a/lib/easy/deployment/capistrano.rb
+++ b/lib/easy/deployment/capistrano.rb
@@ -74,7 +74,7 @@ Capistrano::Configuration.instance(:must_exist).load do
           "ssh-add"
         end
         Capistrano::CLI.ui.say("<%= color('Error, no ssh-keys registered to be forwarded', :red) %>")
-        Capistrano::CLI.ui.say("<%= color('Run the following command to register your ssh-key then try again:', :red) #{cmd_to_run} %>")
+        Capistrano::CLI.ui.say("<%= color('Run the following command to register your ssh-key then try again:', :red) %> #{cmd_to_run}")
         exit(1)
       else
         Capistrano::CLI.ui.say("<%= color('ssh-keys are good to go captain!', :cyan) %>") if ENV['DEBUG']


### PR DESCRIPTION
Recently had an issue with someone trying to deploy without an ssh-key added. It's much more ideal to detect this issue, rather than have a comment within the ruby source here telling them what to do. The lack of working ssh-key forwarding can be tricky to debug in certain cases such as if other keys are present on the target machine (particularly if those are GitHub deploy keys for a _different_ repo).

This makes the deployment system easier to setup for first time users.
