### PR TITLE
Support for standalone ruby app servers and nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Replace any missing configuration lines, and don't forget to remove the TODO tex
 
 ## Integration
 
-### Apache
+### Apache (via Passenger)
 
 Automatically setup an Apache V-Host, and reload apache2:
 
@@ -43,7 +43,7 @@ Add to deploy.rb
 
     require "easy/deployment/apache"
 
-Customise the vhost file within `config/deploy/<stage>/apache/<app>.conf`
+Customise the vhost file within `config/deploy/<stage>/apache.conf`
 If necessary, you can set the path to the apache2ctl binary via:
 
     set :apachectl_bin, "/usr/sbin/apachectl"
@@ -55,6 +55,26 @@ This assumes your deploy user has access to run the apachectl command with sudo 
     deploy ALL=(ALL) NOPASSWD:/usr/sbin/apachectl configtest
 
 Read more about passenger configuration on our wiki at https://github.com/AbleTech/easy-deployment/wiki/Common-passenger-config
+
+### Nginx (for use with standalone ruby app server)
+
+Add to deploy.rb
+
+    require "easy/deployment/nginx"
+
+Customise the site configuration within `config/deploy/<stage>/nginx.conf`
+Alter the paths used if required:
+
+    set :nginx_bin, "/etc/init.d/nginx" # This is the default, change if necessary
+    set :nginx_dir, "/etc/nginx"        # This is the default, change if necessary
+
+Like the apache integration, this requires sudo privileges to reload nginx:
+
+This example shows setting a passwordless sudo for a single user `deploy` for a limited set of commands controlling nginx
+
+    # Example sudoers file entries to grant deploy user passwordless sudo privileges to only these commands
+    deploy ALL=(ALL) NOPASSWD:/etc/init.d/nginx reload
+    deploy ALL=(ALL) NOPASSWD:/etc/init.d/nginx configtest
 
 ### Logrotate
 

--- a/lib/easy/deployment/nginx.rb
+++ b/lib/easy/deployment/nginx.rb
@@ -1,0 +1,35 @@
+# Define some defaults for Capistrano deploys.
+# To load this Capistrano configuration, require 'easy/deployment/nginx' from deploy.rb
+
+Capistrano::Configuration.instance(:must_exist).load do
+  def remote_file_exists?(full_path)
+    'true' ==  capture("if [ -e #{full_path} ]; then echo 'true'; fi").strip
+  end
+
+  set :nginx_bin, "/etc/init.d/nginx"
+  set :nginx_dir, "/etc/nginx"
+
+  namespace :nginx do
+    desc "Configure this site, test the configuration & gracefully reload the Nginx configuration"
+    task :configure_and_reload, :roles => :web, :except => { :no_release => true } do
+      configure
+      configtest
+      reload
+    end
+
+    desc "Configure this site with config/deploy/nginx.conf)"
+    task :configure, :roles => :web, :except => { :no_release => true } do
+      run "cp -f #{current_path}/config/deploy/#{stage}/nginx.conf #{nginx_dir}/sites-available/#{application}"
+      run "ln -fs #{nginx_dir}/sites-available/#{application} #{nginx_dir}/sites-enabled/#{application}"
+    end
+
+    [:stop, :start, :restart, :reload, :configtest].each do |action|
+      desc "#{action.to_s.capitalize} Nginx"
+      task action, :roles => :web do
+        run "sudo #{nginx_bin} #{action.to_s}"
+      end
+    end
+  end
+
+  before 'deploy:start', 'nginx:configure_and_reload'
+end

--- a/lib/easy/generators/stage_generator.rb
+++ b/lib/easy/generators/stage_generator.rb
@@ -10,6 +10,7 @@ module Easy
       directory("stage", "config/deploy/#{name}")
       template("stage.rb.tt", "config/deploy/#{name}.rb")
       template("stage/apache.conf.tt", "config/deploy/#{name}/apache.conf")
+      template("stage/nginx.conf.tt", "config/deploy/#{name}/nginx.conf")
 
       # Ensure we have a config/environments/<env-name>.rb
       dest = "config/environments/#{name}.rb"

--- a/lib/easy/generators/templates/stage/nginx.conf.tt
+++ b/lib/easy/generators/templates/stage/nginx.conf.tt
@@ -1,0 +1,28 @@
+upstream <%= application_name %> {
+  server unix:///var/apps/<%= application_name %>/shared/sockets/<%= application_name %>.sock;
+}
+
+server {
+  listen 80;
+  server_name <%= name %>.<%= application_name %>.co.nz;
+  root /var/apps/<%= application_name %>/current/public;
+
+  location / {
+    proxy_pass http://<%= application_name %>; # match the name of upstream directive which is defined above
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
+
+  location ~* ^/assets/ {
+    # Per RFC2616 - 1 year maximum expiry
+    expires 1y;
+    add_header Cache-Control public;
+
+    # Some browsers still send conditional-GET requests if there's a
+    # Last-Modified header or an ETag header even if they haven't
+    # reached the expiry date sent in the Expires header.
+    add_header Last-Modified "";
+    add_header ETag "";
+    break;
+  }
+}


### PR DESCRIPTION
This PR adds support for running your ruby web application on servers such as puma, unicorn, thin etc, and putting an nginx instance in front of using either a unix socket (default), or http if desired.
